### PR TITLE
fix: Arquivo não encontrado impede a execução

### DIFF
--- a/usr/share/bigbashview/bcc/apps/tts/index.sh.htm
+++ b/usr/share/bigbashview/bcc/apps/tts/index.sh.htm
@@ -48,7 +48,7 @@ fi
 # Import BigControlCenter base modules / Importa os módulos básicos do BigControlCenter
 # That's include jquery and materialize / Isso inclui o jquery e o materialize
 # http://materializecss.com/
-. /usr/share/bigbashview/bcc/shell/base.sh
+#. /usr/share/bigbashview/bcc/shell/base.sh
 
 cat << EOF
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a1229ba7-ac33-4feb-8c30-f355c21202cf)

Atualmente esse arquivo não existe mais no bigbashview e impede a execução do narrador de texto