### PR TITLE
fix: symbolic icon dark-mode support and theme awareness

### DIFF
--- a/usr/share/biglinux/tts-biglinux/application.py
+++ b/usr/share/biglinux/tts-biglinux/application.py
@@ -149,11 +149,18 @@ class TTSApplication(Adw.Application):
 
         # Resolve icon fallback path for when theme lookup fails
         icon_fallback = ""
-        for prefix in ["/usr/share", str(Path.home() / ".local/share")]:
+        # Priority: Git repo (for dev), then system paths
+        repo_root = Path(__file__).resolve().parent.parent.parent.parent
+        prefixes = [str(repo_root), "/usr/share", str(Path.home() / ".local/share")]
+        
+        for prefix in prefixes:
+            # When looking in the repo root (dev), icon is in usr/share/icons
+            icon_subdir = "usr/share/icons" if prefix == str(repo_root) else "icons"
             candidate = (
-                f"{prefix}/icons/hicolor/scalable/status/tts-biglinux-symbolic.svg"
+                f"{prefix}/{icon_subdir}/hicolor/scalable/status/tts-biglinux-symbolic.svg"
             )
             if Path(candidate).exists():
+                logger.debug("Found tray icon at: %s", candidate)
                 icon_fallback = candidate
                 break
 

--- a/usr/share/biglinux/tts-biglinux/services/tray_service.py
+++ b/usr/share/biglinux/tts-biglinux/services/tray_service.py
@@ -73,6 +73,16 @@ try:
     tray = QSystemTrayIcon(icon, app)
     tray.setToolTip(tooltip)
 
+    def update_icon():
+        """Refresh icon when theme changes."""
+        new_icon = QIcon(icon_path) if icon_path else QIcon.fromTheme(icon_name)
+        if icon_name.endswith("-symbolic"):
+            new_icon.setIsMask(True)
+        tray.setIcon(new_icon)
+
+    # Listen for theme changes (Light/Dark mode toggle)
+    app.paletteChanged.connect(update_icon)
+
     menu = QMenu()
     tray.setContextMenu(menu)
 

--- a/usr/share/icons/hicolor/scalable/status/tts-biglinux-symbolic.svg
+++ b/usr/share/icons/hicolor/scalable/status/tts-biglinux-symbolic.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
     <style id="current-color-scheme" type="text/css">
         .ColorScheme-Text { color:#232629; }
     </style>


### PR DESCRIPTION
- Standardized tts-biglinux-symbolic.svg for KDE/Plasma color scheme\n- Enhanced tray helper to react instantly to system palette changes\n- Fixed dev icon path in application logic for correct local testing