### PR TITLE
Rewrite Kokoro integration to Python API + fix welcome dialog z-order

### DIFF
--- a/usr/share/biglinux/tts-biglinux/application.py
+++ b/usr/share/biglinux/tts-biglinux/application.py
@@ -195,6 +195,7 @@ class TTSApplication(Adw.Application):
     _notif_dismiss_id: int = 0
     _notif_id: int = 0  # D-Bus notification ID
     _notif_text_len: int = 0  # Length of notified text for proportional delay
+    _notif_body: str = ""  # Last notification body for re-use on countdown
 
     def _on_tts_state_changed(self, state: "TTSState") -> None:
         """Notify tray icon of TTS state changes and process speech queue."""
@@ -219,8 +220,9 @@ class TTSApplication(Adw.Application):
                 display_text = display_text[:120] + "…"
 
             self._notif_text_len = len(spoken_text) if spoken_text else 20
-            # Show or replace existing notification
-            self._show_dbus_notification(display_text)
+            self._notif_body = display_text
+            # Show persistent notification (no auto-expire during speech)
+            self._show_dbus_notification(display_text, expire_timeout=0)
         else:
             # Process speech queue (queue mode)
             if self._speech_queue:
@@ -230,14 +232,30 @@ class TTSApplication(Adw.Application):
 
             # Proportional delay: 40ms per char, min 2s
             delay_ms = max(2000, self._notif_text_len * 40)
+
+            # Re-send same text with expire_timeout → KDE shows countdown bar
+            self._show_dbus_notification(
+                self._notif_body or _("Playing…"),
+                expire_timeout=delay_ms,
+            )
+
+            # Fallback: manual dismiss if notification server ignores expire_timeout
             if self._notif_dismiss_id:
                 GLib.source_remove(self._notif_dismiss_id)
             self._notif_dismiss_id = GLib.timeout_add(
                 delay_ms, self._dismiss_notification,
             )
 
-    def _show_dbus_notification(self, body: str) -> None:
-        """Show notification via org.freedesktop.Notifications D-Bus."""
+    def _show_dbus_notification(
+        self, body: str, *, expire_timeout: int = 0,
+    ) -> None:
+        """Show notification via org.freedesktop.Notifications D-Bus.
+
+        Args:
+            body: Notification body text.
+            expire_timeout: Auto-dismiss delay in ms (0 = server decides).
+                KDE shows a countdown bar when > 0.
+        """
         try:
             proxy = Gio.DBusProxy.new_for_bus_sync(
                 Gio.BusType.SESSION, Gio.DBusProxyFlags.NONE, None,
@@ -255,7 +273,7 @@ class TTSApplication(Adw.Application):
                     body,               # body
                     [],                 # actions
                     {},                 # hints
-                    0,                  # expire_timeout (0 = server decides)
+                    expire_timeout,     # expire_timeout (ms, 0 = server decides)
                 )),
                 Gio.DBusCallFlags.NONE, -1, None,
             )

--- a/usr/share/biglinux/tts-biglinux/services/kokoro_voice_service.py
+++ b/usr/share/biglinux/tts-biglinux/services/kokoro_voice_service.py
@@ -126,12 +126,23 @@ _CATALOG_BY_ID: dict[str, KokoroVoiceEntry] = {v.voice_id: v for v in KOKORO_CAT
 # ── Public API ───────────────────────────────────────────────────────
 
 def is_kokoro_installed() -> bool:
-    """Check if the Kokoro engine (biglinux-kokoro-tts) is installed."""
-    return SYSTEM_VOICES_BIN.exists() and shutil.which("koko") is not None
+    """Check if the Kokoro Python library is importable."""
+    try:
+        import kokoro  # noqa: F401
+        return True
+    except ImportError:
+        return False
 
 
 def get_installed_voice_ids() -> set[str]:
-    """Return set of voice IDs available in the active voices.bin."""
+    """Return set of voice IDs available.
+
+    With the Python API, all catalog voices are available on demand
+    (KPipeline downloads from HuggingFace on first use).
+    Falls back to voices.bin if present.
+    """
+    if is_kokoro_installed():
+        return {v.voice_id for v in KOKORO_CATALOG}
     voices_bin = _active_voices_bin()
     if not voices_bin.exists():
         return set()

--- a/usr/share/biglinux/tts-biglinux/services/tts_service.py
+++ b/usr/share/biglinux/tts-biglinux/services/tts_service.py
@@ -17,7 +17,6 @@ from collections.abc import Callable
 from typing import Any
 
 from config import TTSBackend, TTSState, KokoroConfig
-from services.kokoro_voice_service import get_active_voices_bin
 from services.text_processor import process_text
 from services.voice_manager import VoiceInfo
 from utils.speechd_utils import try_restart_speechd
@@ -47,59 +46,6 @@ OnProgress = Callable[[str], None]
 
 # Watch interval in ms for process completion
 _WATCH_INTERVAL_MS = 300
-
-# koko text crashes (SIGABRT) on input > ~410 chars.
-# Split at sentence boundaries, keeping each chunk under this limit.
-_KOKORO_MAX_CHUNK = 200
-
-# Regex: sentence-ending punctuation followed by whitespace
-import re
-_SENTENCE_SPLIT_RE = re.compile(r'(?<=[.!?;:…])\s+')
-
-
-def _split_kokoro_text(text: str) -> list[str]:
-    """Split text into chunks safe for koko text (≤ _KOKORO_MAX_CHUNK chars).
-
-    Splits at sentence boundaries first, then at word boundaries if a sentence
-    still exceeds the limit.
-    """
-    sentences = _SENTENCE_SPLIT_RE.split(text.strip())
-    chunks: list[str] = []
-    current = ""
-
-    for sentence in sentences:
-        sentence = sentence.strip()
-        if not sentence:
-            continue
-
-        # If adding this sentence fits, accumulate
-        if current and len(current) + 1 + len(sentence) <= _KOKORO_MAX_CHUNK:
-            current += " " + sentence
-        elif not current and len(sentence) <= _KOKORO_MAX_CHUNK:
-            current = sentence
-        else:
-            # Flush current chunk
-            if current:
-                chunks.append(current)
-                current = ""
-
-            if len(sentence) <= _KOKORO_MAX_CHUNK:
-                current = sentence
-            else:
-                # Sentence too long — split at word boundaries
-                words = sentence.split()
-                for word in words:
-                    if current and len(current) + 1 + len(word) <= _KOKORO_MAX_CHUNK:
-                        current += " " + word
-                    else:
-                        if current:
-                            chunks.append(current)
-                        current = word
-
-    if current:
-        chunks.append(current)
-
-    return chunks if chunks else [text[:_KOKORO_MAX_CHUNK]]
 
 
 class TTSService:
@@ -814,19 +760,18 @@ class TTSService:
     def _speak_kokoro(
         self, text: str, voice_id: str, rate: int, pitch: int, volume: int
     ) -> bool:
-        """Speak via Kokoro neural TTS using the koko CLI binary.
+        """Speak via Kokoro neural TTS using the Python API.
 
         voice_id format: "kokoro:af_heart" or "kokoro:pf_dora"
-        Uses the koko binary from biglinux-kokoro-tts package.
-
-        Strategy: generate audio to a temp WAV file via `koko text`, then play
-        it back — same approach as _speak_piper.
+        Uses kokoro.KPipeline to generate audio, then plays via aplay/sox.
         """
         import tempfile
 
-        koko_bin = shutil.which("koko")
-        if not koko_bin:
-            logger.error("koko binary not found — install biglinux-kokoro-tts")
+        try:
+            from kokoro import KPipeline
+            import soundfile as sf
+        except ImportError:
+            logger.error("Kokoro library not installed — pip install kokoro soundfile")
             return False
 
         # Read Kokoro-specific settings
@@ -841,31 +786,14 @@ class TTSService:
         if not kokoro_voice:
             kokoro_voice = "pf_dora"  # Default Brazilian Portuguese
 
-        # Determine lang_code — prefer KokoroConfig, fallback to voice prefix
+        # Determine lang_code — single-letter code for KPipeline
         voice_prefix = kokoro_voice[:1] if kokoro_voice else "p"
-        lang_code_map = {
-            "a": "en-us",  # American English
-            "b": "en-gb",  # British English
-            "e": "es",     # Spanish
-            "f": "fr",     # French
-            "h": "hi",     # Hindi
-            "i": "it",     # Italian
-            "j": "ja",     # Japanese
-            "p": "pt-br",  # Brazilian Portuguese
-            "z": "zh",     # Mandarin Chinese
-        }
-        lang_code = lang_code_map.get(voice_prefix, "pt-br")
+        lang_code = voice_prefix  # KPipeline uses single-letter codes directly
         if kokoro_cfg and kokoro_cfg.lang_code:
-            # Map single-letter config codes to espeak-ng language codes
-            cfg_lang_map = {
-                "a": "en-us", "b": "en-gb", "e": "es", "f": "fr",
-                "h": "hi", "i": "it", "j": "ja", "p": "pt-br", "z": "zh",
-            }
-            lang_code = cfg_lang_map.get(kokoro_cfg.lang_code, kokoro_cfg.lang_code)
+            lang_code = kokoro_cfg.lang_code
 
         # ── Speed calculation ──
         # Base speed from rate slider: (-100..100) → (0.5..2.0)
-        # koko: 0.5=slow, 1.0=normal, 2.0=fast
         base_speed = 1.0 + (rate / 100.0)
         base_speed = max(0.5, min(2.0, base_speed))
 
@@ -881,62 +809,29 @@ class TTSService:
         emotion_factor = _EMOTION_SPEED.get(emotion, 1.0)
         speed = max(0.5, min(2.0, base_speed * emotion_factor))
 
-        # Set environment for model/data paths (needed before blend validation)
-        koko_env = {**os.environ,
-            "KOKO_MODEL_PATH": "/usr/share/biglinux-kokoro-tts/model/model.onnx",
-            "KOKO_DATA_PATH": str(get_active_voices_bin()),
-        }
-
-        # ── Voice blending ──
-        style = kokoro_voice
-        if kokoro_cfg and kokoro_cfg.voice_blend:
-            blend_voice = kokoro_cfg.voice_blend.strip()
-            # Strip "kokoro:" prefix — voice_blend stores catalog IDs
-            if blend_voice.startswith("kokoro:"):
-                blend_voice = blend_voice[7:]
-            blend_ratio = max(0.0, min(1.0, kokoro_cfg.blend_ratio))
-            if blend_voice and blend_voice != kokoro_voice:
-                # Validate blend voice exists before using it —
-                # koko falls back to a random voice if the blend voice is missing
-                blend_valid = self._is_kokoro_voice_available(
-                    blend_voice, koko_bin, koko_env,
-                )
-                if blend_valid:
-                    # koko format: voice1.weight+voice2.weight (weights 0-10)
-                    w1 = round((1.0 - blend_ratio) * 10)
-                    w2 = round(blend_ratio * 10)
-                    style = f"{kokoro_voice}.{w1}+{blend_voice}.{w2}"
-                else:
-                    logger.warning(
-                        "Kokoro blend voice '%s' not installed, using '%s' alone",
-                        blend_voice, kokoro_voice,
-                    )
-
         # Volume factor (0..100 → 0.2..2.0)
         vol_factor = max(0.2, min(2.0, volume / 50.0)) if volume > 0 else 0.2
 
         logger.debug(
-            "Kokoro: voice=%s, style=%s, lang=%s, speed=%.2f, "
+            "Kokoro: voice=%s, lang=%s, speed=%.2f, "
             "emotion=%s, vol=%.2f, text=%r",
-            kokoro_voice, style, lang_code, speed,
+            kokoro_voice, lang_code, speed,
             emotion, vol_factor, text[:60],
         )
 
-        # koko text crashes (SIGABRT) on text > ~410 chars.
-        # Split into sentence-boundary chunks and process sequentially.
-        chunks = _split_kokoro_text(text)
-        logger.debug("Kokoro: split into %d chunk(s)", len(chunks))
+        # Create or reuse cached pipeline
+        cached_lang = getattr(self, "_kokoro_cached_lang", None)
+        if cached_lang != lang_code or not hasattr(self, "_kokoro_api_pipeline"):
+            try:
+                self._kokoro_api_pipeline = KPipeline(lang_code=lang_code)
+                self._kokoro_cached_lang = lang_code
+            except Exception as e:
+                logger.error("Failed to create KPipeline: %s", e)
+                return False
 
-        # Base command template — text and output path filled per chunk
-        base_cmd = [
-            koko_bin,
-            "-s", style,
-            "-l", lang_code,
-            "-p", f"{speed:.2f}",
-            "--force-style", "true",
-        ]
+        pipeline = self._kokoro_api_pipeline
 
-        # Check sox availability once
+        # Check sox availability for volume control
         sox_available = shutil.which("sox") is not None
 
         def _build_play_cmd(wav_path: str) -> list[str]:
@@ -945,62 +840,31 @@ class TTSService:
             return ["aplay", "-q", wav_path]
 
         def _generate_and_play() -> None:
-            """Pipeline: generate next chunk while current plays."""
+            """Generate audio via KPipeline and play chunks sequentially."""
             tmp_paths: list[str] = []
             play_proc: subprocess.Popen | None = None
 
-            def _gen_chunk(chunk: str) -> str | None:
-                """Generate a WAV for one chunk, return path or None on failure."""
-                tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
-                path = tmp.name
-                tmp.close()
-                tmp_paths.append(path)
-
-                cmd = [*base_cmd, "text", "-o", path, chunk]
-                proc = subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.PIPE,
-                    env=koko_env,
-                )
-                self._kokoro_proc = proc
-                proc.wait()
-                self._kokoro_proc = None
-
-                if self._kokoro_stop_event.is_set():
-                    return None
-                if proc.returncode != 0:
-                    if proc.returncode != -9:
-                        stderr = (
-                            proc.stderr.read().decode("utf-8", errors="replace")
-                            if proc.stderr else ""
-                        )
-                        logger.error("Kokoro gen failed (code %d): %s",
-                                     proc.returncode, stderr[-200:])
-                    return None
-                if not os.path.isfile(path) or os.path.getsize(path) < 100:
-                    logger.error("Kokoro generated empty audio")
-                    return None
-                return path
-
             try:
-                for i, chunk in enumerate(chunks):
+                generator = pipeline(text, voice=kokoro_voice, speed=speed)
+
+                for _gs, _ps, audio in generator:
                     if self._kokoro_stop_event.is_set():
                         if play_proc:
                             play_proc.terminate()
                         return
 
-                    # Generate this chunk
-                    wav = _gen_chunk(chunk)
-                    if wav is None:
-                        if play_proc:
-                            play_proc.terminate()
-                        self._set_state(TTSState.ERROR)
-                        return
+                    if audio is None or len(audio) < 100:
+                        continue
 
-                    # Wait for previous chunk playback to finish
+                    # Write audio chunk to temp WAV
+                    tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+                    path = tmp.name
+                    tmp.close()
+                    tmp_paths.append(path)
+                    sf.write(path, audio, 24000)
+
+                    # Wait for previous chunk to finish playing
                     if play_proc:
-                        # Poll with stop-event check instead of blocking wait
                         while play_proc.poll() is None:
                             if self._kokoro_stop_event.is_set():
                                 play_proc.terminate()
@@ -1008,30 +872,33 @@ class TTSService:
                             self._kokoro_stop_event.wait(timeout=0.05)
 
                     # Start playing this chunk
-                    play_cmd = _build_play_cmd(wav)
+                    play_cmd = _build_play_cmd(path)
                     play_proc = subprocess.Popen(
                         play_cmd,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
                     )
-                    # Track so stop() can kill it
                     self._process = play_proc
 
-                # Keep last play_proc tracked for watch
+                # Wait for last chunk
                 if play_proc:
-                    self._piper_tmp_path = tmp_paths[-1] if tmp_paths else None
+                    while play_proc.poll() is None:
+                        if self._kokoro_stop_event.is_set():
+                            play_proc.terminate()
+                            return
+                        self._kokoro_stop_event.wait(timeout=0.05)
 
-            except (FileNotFoundError, OSError) as e:
-                logger.error("Failed to start Kokoro: %s", e)
+            except Exception as e:
+                logger.error("Kokoro generation failed: %s", e)
+                if play_proc and play_proc.poll() is None:
+                    play_proc.terminate()
                 self._set_state(TTSState.ERROR)
             finally:
-                playing = getattr(self, "_piper_tmp_path", None)
                 for p in tmp_paths:
-                    if p != playing:
-                        try:
-                            os.unlink(p)
-                        except OSError:
-                            pass
+                    try:
+                        os.unlink(p)
+                    except OSError:
+                        pass
 
         self._kokoro_stop_event.clear()
         self._kokoro_thread = threading.Thread(
@@ -1039,45 +906,6 @@ class TTSService:
         )
         self._kokoro_thread.start()
         return True
-
-    def _is_kokoro_voice_available(
-        self,
-        voice_name: str,
-        koko_bin: str,
-        koko_env: dict[str, str],
-    ) -> bool:
-        """Check if a Kokoro voice style is installed.
-
-        Uses a cached set populated from `koko voices` on first call.
-        Cache is invalidated when the active voices.bin changes.
-        """
-        current_bin = koko_env.get("KOKO_DATA_PATH", "")
-        if (
-            not hasattr(self, "_kokoro_available_voices")
-            or getattr(self, "_kokoro_voices_bin_path", "") != current_bin
-        ):
-            self._kokoro_voices_bin_path = current_bin
-            self._kokoro_available_voices: set[str] = set()
-            try:
-                proc = subprocess.run(
-                    [koko_bin, "voices"],
-                    capture_output=True, text=True, timeout=5,
-                    env=koko_env,
-                )
-                if proc.returncode == 0:
-                    for line in proc.stdout.splitlines():
-                        stripped = line.strip()
-                        if (
-                            stripped
-                            and not stripped.startswith("Voice ID")
-                            and not stripped.startswith("---")
-                            and "loaded:" not in stripped
-                        ):
-                            vid = stripped.split()[0]
-                            self._kokoro_available_voices.add(vid)
-            except (FileNotFoundError, subprocess.TimeoutExpired):
-                pass
-        return voice_name in self._kokoro_available_voices
 
     def _start_process(self, cmd: list[str], text: str) -> bool:
         """Start a TTS process with text piped to stdin."""

--- a/usr/share/biglinux/tts-biglinux/ui/main_view.py
+++ b/usr/share/biglinux/tts-biglinux/ui/main_view.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import threading
 from collections.abc import Callable
 from contextlib import contextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING, Iterator
 
 import gi
@@ -35,6 +37,7 @@ from config import (
     VOLUME_STEP,
 )
 from services.desktop_integration_service import DesktopIntegrationService
+from services.kokoro_voice_service import is_kokoro_installed
 from services.text_processor import get_system_language
 from services.voice_manager import (
     VoiceCatalog,
@@ -1070,6 +1073,11 @@ class MainView(Adw.NavigationPage):
             )
             return
 
+        # Kokoro: check if engine is installed before anything else
+        if backend == TTSBackend.KOKORO.value and not is_kokoro_installed():
+            self._ask_install_kokoro()
+            return
+
         # Refresh voices for new backend
         if self._catalog:
             filtered = self._catalog.get_by_backend(backend)
@@ -1083,6 +1091,14 @@ class MainView(Adw.NavigationPage):
                 run_in_thread(
                     discover_voices,
                     on_done=lambda cat: self._on_piper_discovery_retry(cat),
+                )
+                return
+            elif backend == TTSBackend.KOKORO.value:
+                # Kokoro installed but no voices — re-discover
+                self._voice_combo.set_subtitle(_("Checking for Kokoro voices..."))
+                run_in_thread(
+                    discover_voices,
+                    on_done=self._on_voices_discovered,
                 )
                 return
             else:
@@ -1132,7 +1148,180 @@ class MainView(Adw.NavigationPage):
                     self._on_voices_discovered(self._catalog)
             return
 
-        self._on_toast(_("Installing Piper TTS — this may take a moment…"), 5)
+        self._run_install_with_progress(
+            title=_("Installing Piper TTS"),
+            status_text=_("Downloading and installing packages…"),
+            worker=self._install_piper_packages,
+            on_done=self._on_piper_installed,
+        )
+
+    def _ask_install_kokoro(self) -> None:
+        """Show dialog to install Kokoro Neural TTS."""
+        dialog = Adw.AlertDialog.new(
+            _("Install Kokoro Neural TTS?"),
+            _(
+                "Kokoro is not installed. It provides high-quality neural "
+                "voices with emotion presets and voice blending.\n\n"
+                "System dependencies (PyTorch, scipy, espeak-ng) will be "
+                "installed via pacman.\n"
+                "The Kokoro library will be installed via pip."
+            ),
+        )
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("install", _("Install"))
+        dialog.set_response_appearance("install", Adw.ResponseAppearance.SUGGESTED)
+        dialog.set_default_response("install")
+        dialog.set_close_response("cancel")
+        dialog.connect("response", self._on_install_kokoro_response)
+
+        window = self.get_root()
+        dialog.present(window)
+
+    def _on_install_kokoro_response(
+        self, dialog: Adw.AlertDialog, response: str
+    ) -> None:
+        """Handle Kokoro install dialog response."""
+        if response != "install":
+            with self._guard_ui():
+                prev_backend = TTSBackend.RHVOICE.value
+                self._settings.speech.backend = prev_backend
+                self._settings_service.save(self._settings)
+                self._backend_combo.set_selected(0)
+                if self._catalog:
+                    self._on_voices_discovered(self._catalog)
+            return
+
+        self._run_install_with_progress(
+            title=_("Installing Kokoro TTS"),
+            status_text=_("Downloading and installing packages…"),
+            worker=self._install_kokoro_packages,
+            on_done=self._on_kokoro_installed,
+        )
+
+    def _run_install_with_progress(
+        self,
+        title: str,
+        status_text: str,
+        worker: Callable[[], tuple[bool, str]],
+        on_done: Callable[[tuple[bool, str]], None],
+    ) -> None:
+        """Show a progress dialog and run a package install in background."""
+        progress_dialog = Adw.AlertDialog.new(title, status_text)
+        progress_dialog.set_can_close(False)
+
+        # Add a progress bar as extra child
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(12)
+
+        progress_bar = Gtk.ProgressBar()
+        progress_bar.set_show_text(False)
+        progress_bar.pulse()
+        box.append(progress_bar)
+
+        progress_dialog.set_extra_child(box)
+
+        window = self.get_root()
+        progress_dialog.present(window)
+
+        # Pulse the progress bar while installing
+        def _pulse() -> bool:
+            if not hasattr(progress_dialog, "_install_running"):
+                return False
+            progress_bar.pulse()
+            return True
+
+        progress_dialog._install_running = True
+        GLib.timeout_add(200, _pulse)
+
+        def _threaded() -> None:
+            result = worker()
+
+            def _finish() -> bool:
+                del progress_dialog._install_running
+                progress_dialog.set_can_close(True)
+                progress_dialog.force_close()
+                on_done(result)
+                return False
+
+            GLib.idle_add(_finish)
+
+        threading.Thread(target=_threaded, daemon=True).start()
+
+    def _install_kokoro_packages(self) -> tuple[bool, str]:
+        """Install Kokoro TTS: system deps via pacman + kokoro via pip."""
+        try:
+            lock_file = Path("/var/lib/pacman/db.lck")
+            if lock_file.exists():
+                return False, _("Database is locked by another process")
+
+            # Step 1: system deps via pacman (uses pkexec for graphical auth)
+            sys_deps = [
+                "python-pytorch", "python-numpy", "python-scipy",
+                "python-transformers", "python-huggingface-hub",
+                "python-loguru", "espeak-ng",
+            ]
+            result = subprocess.run(
+                ["pkexec", "pacman", "-S", "--noconfirm", "--needed", *sys_deps],
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+            if result.returncode != 0:
+                stderr = result.stderr.strip()
+                error_msg = stderr.splitlines()[-1] if stderr else _("pacman failed")
+                return False, error_msg
+
+            # Step 2: kokoro + soundfile via pip (user-local, no root needed)
+            result = subprocess.run(
+                [
+                    "pip3", "install", "--user",
+                    "--break-system-packages",
+                    "kokoro", "soundfile",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            if result.returncode != 0:
+                stderr = result.stderr.strip()
+                error_msg = stderr.splitlines()[-1] if stderr else _("pip install failed")
+                return False, error_msg
+
+            return True, ""
+        except FileNotFoundError as e:
+            return False, _("Command not found: {cmd}").format(cmd=str(e))
+        except subprocess.TimeoutExpired:
+            return False, _("Installation timed out")
+        except Exception as e:
+            return False, str(e)
+
+    def _on_kokoro_installed(self, result: tuple[bool, str]) -> None:
+        """Called after Kokoro install completes."""
+        success, error_msg = result
+        if success:
+            self._on_toast(_("Kokoro installed successfully! Discovering voices…"), 3)
+
+            def _on_done(catalog: VoiceCatalog) -> None:
+                self._on_voices_discovered(catalog)
+                with self._guard_ui():
+                    self._backend_combo.set_selected(3)
+                    self._on_backend_selected(3)
+
+            run_in_thread(discover_voices, on_done=_on_done)
+        else:
+            if error_msg:
+                self._on_toast(
+                    _("Failed to install: {error}").format(error=error_msg), 5
+                )
+            else:
+                self._on_toast(_("Failed to install Kokoro — check permissions"), 5)
+            with self._guard_ui():
+                self._settings.speech.backend = TTSBackend.RHVOICE.value
+                self._settings_service.save(self._settings)
+                self._backend_combo.set_selected(0)
+                if self._catalog:
+                    self._on_voices_discovered(self._catalog)
+
     def _on_piper_discovery_retry(self, catalog: VoiceCatalog) -> None:
         """Second attempt at discovery after switching to Piper."""
         self._catalog = catalog

--- a/usr/share/biglinux/tts-biglinux/window.py
+++ b/usr/share/biglinux/tts-biglinux/window.py
@@ -146,6 +146,8 @@ class TTSWindow(Adw.ApplicationWindow):
             application=self._app,
             settings_service=self._app.settings_service,
         )
+        win.set_transient_for(self)
+        win.set_modal(True)
         win.present()
         return GLib.SOURCE_REMOVE
 


### PR DESCRIPTION
- Rewrite _speak_kokoro() to use KPipeline Python API instead of koko CLI
- Rewrite is_kokoro_installed() to check via import instead of binary/file
- Update get_installed_voice_ids() to return full catalog when installed
- Replace pamac install with pacman (sys deps) + pip (kokoro, soundfile)
- Remove dead code: _split_kokoro_text, _is_kokoro_voice_available
- Add KDE notification countdown via D-Bus expire_timeout
- Fix welcome window appearing behind main window (transient + modal)