### PR TITLE
Add cross-DE shortcut support + dual Kokoro backend (Python/koko)

### DIFF
--- a/usr/share/biglinux/tts-biglinux/application.py
+++ b/usr/share/biglinux/tts-biglinux/application.py
@@ -28,6 +28,7 @@ from config import (
 )
 from resources import load_css
 from services.settings_service import SettingsService
+from services.desktop_integration_service import DesktopIntegrationService
 from services.tray_service import MenuItem, TrayIcon
 from services.tts_service import TTSService
 from utils.i18n import _
@@ -438,28 +439,29 @@ class TTSApplication(Adw.Application):
     # ── Shortcut Registration ────────────────────────────────────────
 
     def _ensure_shortcut_registered(self) -> None:
-        """Register shortcut with KGlobalAccel (services group) on Plasma 6."""
-        import subprocess
-        from pathlib import Path
+        """Register global shortcut for the current desktop environment.
 
+        Supports KDE/Plasma, GNOME, XFCE, and Cinnamon.
+        """
+        shortcut = self.settings.shortcut.keybinding
+        de = DesktopIntegrationService.detect_desktop_environment()
+
+        if de == "kde":
+            self._ensure_shortcut_registered_kde(shortcut)
+        else:
+            # GNOME, XFCE, Cinnamon, or unknown — use cross-DE dispatcher
+            DesktopIntegrationService.register_shortcut_for_current_de(shortcut)
+
+    def _ensure_shortcut_registered_kde(self, shortcut: str) -> None:
+        """Register shortcut with KGlobalAccel (services group) on Plasma 6."""
         # Disable legacy khotkeys binding (it hardcodes Alt+V and conflicts
         # with the new configurable shortcut mechanism)
         self._disable_legacy_khotkeys()
 
         rc_path = Path.home() / ".config" / "kglobalshortcutsrc"
-        shortcut = self.settings.shortcut.keybinding
 
         # Convert GTK accelerator to KDE format
-        kde_shortcut = shortcut
-        kde_shortcut = kde_shortcut.replace("<Control>", "Ctrl+")
-        kde_shortcut = kde_shortcut.replace("<Shift>", "Shift+")
-        kde_shortcut = kde_shortcut.replace("<Alt>", "Alt+")
-        kde_shortcut = kde_shortcut.replace("<Super>", "Meta+")
-        if "+" in kde_shortcut:
-            parts = kde_shortcut.rsplit("+", 1)
-            kde_shortcut = parts[0] + "+" + parts[1].upper()
-        else:
-            kde_shortcut = kde_shortcut.upper()
+        kde_shortcut = DesktopIntegrationService.gtk_accel_to_kde(shortcut)
 
         # Check if already registered correctly in the services group
         already_correct = False
@@ -467,7 +469,6 @@ class TTSApplication(Adw.Application):
             try:
                 content = rc_path.read_text(encoding="utf-8")
                 import re
-                # Match within [services][biglinux-tts-speak.desktop] group
                 match = re.search(
                     r"\[services\]\[biglinux-tts-speak\.desktop\]\s*\n_launch=([^\t\n]+)",
                     content,
@@ -481,7 +482,7 @@ class TTSApplication(Adw.Application):
             logger.debug("Shortcut already registered correctly: %s", kde_shortcut)
             return
 
-        logger.info("Registering global shortcut: %s", kde_shortcut)
+        logger.info("Registering KDE global shortcut: %s", kde_shortcut)
 
         # Remove stale component-level entry if present (legacy, wrong group)
         try:

--- a/usr/share/biglinux/tts-biglinux/services/desktop_integration_service.py
+++ b/usr/share/biglinux/tts-biglinux/services/desktop_integration_service.py
@@ -610,3 +610,296 @@ Type=SHORTCUT
                 )
             except:
                 pass
+
+    # ── Cross-DE Shortcut Support ────────────────────────────────────
+
+    @staticmethod
+    def detect_desktop_environment() -> str:
+        """Detect current desktop environment from XDG_CURRENT_DESKTOP.
+
+        Returns one of: 'kde', 'gnome', 'xfce', 'cinnamon', 'unknown'.
+        """
+        xdg = os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
+        if "kde" in xdg or "plasma" in xdg:
+            return "kde"
+        if "gnome" in xdg or "unity" in xdg:
+            return "gnome"
+        if "xfce" in xdg:
+            return "xfce"
+        if "cinnamon" in xdg or "x-cinnamon" in xdg:
+            return "cinnamon"
+        # Fallback: check DESKTOP_SESSION
+        session = os.environ.get("DESKTOP_SESSION", "").lower()
+        for key, val in [
+            ("plasma", "kde"), ("kde", "kde"),
+            ("gnome", "gnome"), ("ubuntu", "gnome"),
+            ("xfce", "xfce"), ("xubuntu", "xfce"),
+            ("cinnamon", "cinnamon"),
+        ]:
+            if key in session:
+                return val
+        return "unknown"
+
+    @staticmethod
+    def _exec_path_for_speak() -> str:
+        """Resolve the exec path for the speak command."""
+        import sys
+        repo_root = Path(__file__).resolve().parent.parent.parent.parent.parent.parent
+        main_py = repo_root / "usr" / "share" / "biglinux" / "tts-biglinux" / "main.py"
+        if main_py.exists() and (repo_root / ".git").exists():
+            return f"{sys.executable} {main_py} --speak"
+        return "/usr/bin/biglinux-tts-speak"
+
+    @staticmethod
+    def gtk_accel_to_xdg(accel: str) -> str:
+        """Convert GTK accelerator to XDG/gsettings format (used by GNOME/Cinnamon).
+
+        GTK: '<Alt>v' → XDG: '<Alt>v' (same format, just ensure consistency).
+        """
+        # gsettings uses the same format as GTK accelerators
+        return accel
+
+    @classmethod
+    def register_gnome_shortcut(cls, accel: str, exec_path: str) -> bool:
+        """Register custom keybinding in GNOME via gsettings.
+
+        GNOME stores custom shortcuts under:
+          org.gnome.settings-daemon.plugins.media-keys custom-keybindings
+        Each binding is a separate dconf path: .../customN/
+        """
+        import json
+
+        schema = "org.gnome.settings-daemon.plugins.media-keys"
+        base_path = "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings"
+        binding_name = "BigLinux TTS Speak"
+        slot_path = f"{base_path}/biglinux-tts/"
+
+        # Check if our slot already exists
+        try:
+            result = subprocess.run(
+                ["gsettings", "get", schema, "custom-keybindings"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode != 0:
+                logger.warning("gsettings not available for GNOME shortcuts")
+                return False
+            # Parse the list (GVariant format: ['path1', 'path2'])
+            raw = result.stdout.strip()
+            if raw == "@as []" or raw == "[]":
+                current_paths: list[str] = []
+            else:
+                # GVariant uses single-quotes; parse manually
+                current_paths = [
+                    p.strip().strip("'\"")
+                    for p in raw.strip("[]").split(",")
+                    if p.strip()
+                ]
+        except (OSError, subprocess.TimeoutExpired):
+            logger.warning("Failed to read GNOME custom-keybindings")
+            return False
+
+        # Add our slot path if missing
+        if slot_path not in current_paths:
+            current_paths.append(slot_path)
+            paths_str = "[" + ", ".join(f"'{p}'" for p in current_paths) + "]"
+            try:
+                subprocess.run(
+                    ["gsettings", "set", schema, "custom-keybindings", paths_str],
+                    timeout=5, check=True,
+                )
+            except (OSError, subprocess.TimeoutExpired, subprocess.CalledProcessError) as e:
+                logger.error("Failed to register GNOME keybinding slot: %s", e)
+                return False
+
+        # Set the binding properties
+        custom_schema = f"{schema}.custom-keybinding"
+        custom_path = slot_path
+        cmds = [
+            ["gsettings", "set", f"{custom_schema}:{custom_path}", "name", binding_name],
+            ["gsettings", "set", f"{custom_schema}:{custom_path}", "command", exec_path],
+            ["gsettings", "set", f"{custom_schema}:{custom_path}", "binding", accel],
+        ]
+        for cmd in cmds:
+            try:
+                subprocess.run(cmd, timeout=5, check=True)
+            except (OSError, subprocess.TimeoutExpired, subprocess.CalledProcessError) as e:
+                logger.error("Failed to set GNOME keybinding property: %s", e)
+                return False
+
+        logger.info("GNOME shortcut registered: %s → %s", accel, exec_path)
+        return True
+
+    @classmethod
+    def register_xfce_shortcut(cls, accel: str, exec_path: str) -> bool:
+        """Register custom keybinding in XFCE via xfconf-query.
+
+        XFCE stores shortcuts in xfce4-keyboard-shortcuts channel.
+        Path format: /commands/custom/<accel>
+        """
+        import shutil
+
+        if not shutil.which("xfconf-query"):
+            logger.warning("xfconf-query not available — cannot register XFCE shortcut")
+            return False
+
+        # Convert GTK accel to XFCE format — XFCE uses same style but
+        # may need uppercase key name
+        xfce_accel = accel  # '<Alt>v' works in XFCE
+
+        channel = "xfce4-keyboard-shortcuts"
+        prop_path = f"/commands/custom/{xfce_accel}"
+
+        # First, remove any previous biglinux-tts binding
+        try:
+            result = subprocess.run(
+                ["xfconf-query", "-c", channel, "-l", "-v"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    if "biglinux-tts" in line:
+                        parts = line.split(None, 1)
+                        if parts:
+                            old_prop = parts[0]
+                            subprocess.run(
+                                ["xfconf-query", "-c", channel, "-p", old_prop, "-r"],
+                                timeout=3, check=False,
+                            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+        # Register the new binding
+        try:
+            subprocess.run(
+                [
+                    "xfconf-query", "-c", channel,
+                    "-p", prop_path,
+                    "-n", "-t", "string", "-s", exec_path,
+                ],
+                timeout=5, check=True,
+            )
+            logger.info("XFCE shortcut registered: %s → %s", xfce_accel, exec_path)
+            return True
+        except (OSError, subprocess.TimeoutExpired, subprocess.CalledProcessError) as e:
+            logger.error("Failed to register XFCE shortcut: %s", e)
+            return False
+
+    @classmethod
+    def register_cinnamon_shortcut(cls, accel: str, exec_path: str) -> bool:
+        """Register custom keybinding in Cinnamon via gsettings.
+
+        Cinnamon uses a numbered list of custom keybindings under:
+          org.cinnamon.desktop.keybindings custom-list
+        Each binding: org.cinnamon.desktop.keybindings.custom-keybinding:/…/customN/
+        """
+        binding_name = "BigLinux TTS Speak"
+        list_schema = "org.cinnamon.desktop.keybindings"
+        custom_schema = "org.cinnamon.desktop.keybindings.custom-keybinding"
+        base_path = "/org/cinnamon/desktop/keybindings/custom-keybindings"
+
+        # Read current custom-list
+        try:
+            result = subprocess.run(
+                ["gsettings", "get", list_schema, "custom-list"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode != 0:
+                logger.warning("gsettings not available for Cinnamon shortcuts")
+                return False
+
+            raw = result.stdout.strip()
+            if raw == "@as []" or raw == "[]":
+                current_list: list[str] = []
+            else:
+                current_list = [
+                    p.strip().strip("'\"")
+                    for p in raw.strip("[]").split(",")
+                    if p.strip()
+                ]
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+
+        # Check if we already have a slot — look for existing biglinux entry
+        our_slot: str | None = None
+        for slot_id in current_list:
+            slot_path = f"{base_path}/{slot_id}/"
+            try:
+                result = subprocess.run(
+                    ["gsettings", "get", f"{custom_schema}:{slot_path}", "name"],
+                    capture_output=True, text=True, timeout=3,
+                )
+                if binding_name in result.stdout:
+                    our_slot = slot_id
+                    break
+            except (OSError, subprocess.TimeoutExpired):
+                continue
+
+        # Allocate new slot if needed
+        if our_slot is None:
+            # Find next available number
+            existing_nums = set()
+            for s in current_list:
+                if s.startswith("custom"):
+                    try:
+                        existing_nums.add(int(s.removeprefix("custom")))
+                    except ValueError:
+                        pass
+            next_num = 0
+            while next_num in existing_nums:
+                next_num += 1
+            our_slot = f"custom{next_num}"
+            current_list.append(our_slot)
+
+            # Update the list
+            list_str = "[" + ", ".join(f"'{s}'" for s in current_list) + "]"
+            try:
+                subprocess.run(
+                    ["gsettings", "set", list_schema, "custom-list", list_str],
+                    timeout=5, check=True,
+                )
+            except (OSError, subprocess.TimeoutExpired, subprocess.CalledProcessError) as e:
+                logger.error("Failed to update Cinnamon custom-list: %s", e)
+                return False
+
+        # Set binding properties
+        slot_path = f"{base_path}/{our_slot}/"
+        cmds = [
+            ["gsettings", "set", f"{custom_schema}:{slot_path}", "name", binding_name],
+            ["gsettings", "set", f"{custom_schema}:{slot_path}", "command", exec_path],
+            ["gsettings", "set", f"{custom_schema}:{slot_path}", "binding", f"['{accel}']"],
+        ]
+        for cmd in cmds:
+            try:
+                subprocess.run(cmd, timeout=5, check=True)
+            except (OSError, subprocess.TimeoutExpired, subprocess.CalledProcessError) as e:
+                logger.error("Failed to set Cinnamon keybinding: %s", e)
+                return False
+
+        logger.info("Cinnamon shortcut registered: %s → %s", accel, exec_path)
+        return True
+
+    @classmethod
+    def register_shortcut_for_current_de(cls, accel: str) -> bool:
+        """Register the global shortcut using the appropriate DE mechanism.
+
+        Detects the current DE and calls the correct registration method.
+        On KDE, delegates to existing update_khotkeys flow.
+        Returns True if successfully registered.
+        """
+        de = cls.detect_desktop_environment()
+        exec_path = cls._exec_path_for_speak()
+        logger.info("Registering shortcut '%s' for DE: %s", accel, de)
+
+        if de == "kde":
+            cls.update_khotkeys(accel)
+            return True
+        elif de == "gnome":
+            return cls.register_gnome_shortcut(accel, exec_path)
+        elif de == "xfce":
+            return cls.register_xfce_shortcut(accel, exec_path)
+        elif de == "cinnamon":
+            return cls.register_cinnamon_shortcut(accel, exec_path)
+        else:
+            # Unknown DE — try GNOME gsettings as fallback (many DEs are GNOME-based)
+            logger.info("Unknown DE '%s', trying GNOME gsettings as fallback", de)
+            return cls.register_gnome_shortcut(accel, exec_path)

--- a/usr/share/biglinux/tts-biglinux/services/kokoro_voice_service.py
+++ b/usr/share/biglinux/tts-biglinux/services/kokoro_voice_service.py
@@ -126,23 +126,44 @@ _CATALOG_BY_ID: dict[str, KokoroVoiceEntry] = {v.voice_id: v for v in KOKORO_CAT
 # ── Public API ───────────────────────────────────────────────────────
 
 def is_kokoro_installed() -> bool:
-    """Check if the Kokoro Python library is importable."""
+    """Check if Kokoro TTS is available (Python library OR koko binary)."""
     try:
         import kokoro  # noqa: F401
         return True
     except ImportError:
-        return False
+        pass
+    # Fallback: check for koko binary (biglinux-kokoro-tts package)
+    return shutil.which("koko") is not None
+
+
+def kokoro_backend_type() -> str:
+    """Return which Kokoro backend is available.
+
+    Returns:
+        'python' if kokoro Python library is installed,
+        'koko' if koko binary is available,
+        'none' if neither.
+    """
+    try:
+        import kokoro  # noqa: F401
+        return "python"
+    except ImportError:
+        pass
+    if shutil.which("koko") is not None:
+        return "koko"
+    return "none"
 
 
 def get_installed_voice_ids() -> set[str]:
     """Return set of voice IDs available.
 
-    With the Python API, all catalog voices are available on demand
-    (KPipeline downloads from HuggingFace on first use).
-    Falls back to voices.bin if present.
+    - Python kokoro library: all catalog voices (downloads on demand).
+    - koko binary: only voices present in voices.bin.
     """
-    if is_kokoro_installed():
+    backend = kokoro_backend_type()
+    if backend == "python":
         return {v.voice_id for v in KOKORO_CATALOG}
+    # koko binary or detection-only: read from voices.bin
     voices_bin = _active_voices_bin()
     if not voices_bin.exists():
         return set()

--- a/usr/share/biglinux/tts-biglinux/services/tts_service.py
+++ b/usr/share/biglinux/tts-biglinux/services/tts_service.py
@@ -760,10 +760,10 @@ class TTSService:
     def _speak_kokoro(
         self, text: str, voice_id: str, rate: int, pitch: int, volume: int
     ) -> bool:
-        """Speak via Kokoro neural TTS using the Python API.
+        """Speak via Kokoro neural TTS.
 
-        voice_id format: "kokoro:af_heart" or "kokoro:pf_dora"
-        Uses kokoro.KPipeline to generate audio, then plays via aplay/sox.
+        Tries Python kokoro library first (KPipeline), falls back to koko binary
+        (biglinux-kokoro-tts package) if Python lib is not installed.
         """
         import tempfile
 
@@ -771,8 +771,8 @@ class TTSService:
             from kokoro import KPipeline
             import soundfile as sf
         except ImportError:
-            logger.error("Kokoro library not installed — pip install kokoro soundfile")
-            return False
+            # Python kokoro not available — fallback to koko binary
+            return self._speak_kokoro_koko(text, voice_id, rate, pitch, volume)
 
         # Read Kokoro-specific settings
         kokoro_cfg = self._settings.speech.kokoro if self._settings else None
@@ -906,6 +906,48 @@ class TTSService:
         )
         self._kokoro_thread.start()
         return True
+
+    def _speak_kokoro_koko(
+        self, text: str, voice_id: str, rate: int, pitch: int, volume: int
+    ) -> bool:
+        """Speak via koko binary (biglinux-kokoro-tts package).
+
+        Fallback when Python kokoro library is not installed.
+        Uses /usr/bin/koko subprocess with voices.bin.
+        """
+        koko_path = shutil.which("koko")
+        if not koko_path:
+            logger.error("Neither kokoro Python library nor koko binary available")
+            return False
+
+        from services.kokoro_voice_service import get_active_voices_bin
+
+        voices_bin = get_active_voices_bin()
+        if not voices_bin.exists():
+            logger.error("Kokoro voices.bin not found: %s", voices_bin)
+            return False
+
+        # Extract voice name from voice_id
+        kokoro_voice = (
+            voice_id.removeprefix("kokoro:")
+            if voice_id.startswith("kokoro:")
+            else voice_id
+        )
+        if not kokoro_voice:
+            kokoro_voice = "pf_dora"
+
+        # Speed: rate (-100..100) → (0.5..2.0)
+        speed = max(0.5, min(2.0, 1.0 + (rate / 100.0)))
+
+        cmd = [
+            koko_path,
+            "--voice", kokoro_voice,
+            "--voices-bin", str(voices_bin),
+            "--speed", f"{speed:.2f}",
+        ]
+
+        logger.info("Kokoro (koko binary): voice=%s, speed=%.2f", kokoro_voice, speed)
+        return self._start_process(cmd, text)
 
     def _start_process(self, cmd: list[str], text: str) -> bool:
         """Start a TTS process with text piped to stdin."""

--- a/usr/share/biglinux/tts-biglinux/ui/main_view.py
+++ b/usr/share/biglinux/tts-biglinux/ui/main_view.py
@@ -707,10 +707,9 @@ class MainView(Adw.NavigationPage):
         self._on_toast(_("Shortcut changed to {keys}").format(keys=display_name), 3)
         logger.info("Shortcut changed to: %s (%s)", accel, display_name)
 
-        # Update KDE shortcut files in a background thread so the UI
-        # doesn't freeze during subprocess calls and the brief sleep
+        # Update shortcut for the current desktop environment in background
         threading.Thread(
-            target=DesktopIntegrationService.update_khotkeys,
+            target=DesktopIntegrationService.register_shortcut_for_current_de,
             args=(accel,),
             daemon=True,
         ).start()


### PR DESCRIPTION
- Add DE detection (GNOME/XFCE/Cinnamon/KDE) via XDG_CURRENT_DESKTOP
- Register keyboard shortcuts per DE: gsettings (GNOME/Cinnamon), xfconf (XFCE)
- Refactor application.py shortcut registration for cross-DE dispatch
- Add _speak_kokoro_koko() fallback using /usr/bin/koko binary
- Fix get_installed_voice_ids() to use kokoro_backend_type()
- Add kokoro_backend_type() helper (python/koko/none)